### PR TITLE
feat: add sort icon

### DIFF
--- a/icons/sort.svg
+++ b/icons/sort.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 10l9-8 9 8M3 14l9 8 9-8"/></svg>


### PR DESCRIPTION
## Summary
- Add new `sort.svg` icon at 24×24 with up/down chevrons
- Uses `currentColor` stroke to remain colour-agnostic, matching other icons in the set

## Test plan
- [ ] Visual check that the icon renders correctly at 24×24
- [ ] Confirm the icon inherits its colour from the consuming context