### PR TITLE
fix: pin npm to 11.5.2 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install npm 11+ for OIDC support
-        run: npm install -g npm@11
+        run: npm install -g npm@11.5.2 --force
 
       - name: Verify npm OIDC readiness
         run: |


### PR DESCRIPTION
## Summary
The 1.8.21 publish ([failed run](https://github.com/autoguru-au/icons/actions/runs/24543855915/job/71755168391)) crashed at the `Install npm 11+ for OIDC support` step:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`

This is a known npm self-bootstrap bug in a recent npm 11.x release — when `npm install -g npm@11` resolves to the broken version, the in-place CLI upgrade leaves the runtime in an inconsistent module state mid-install.

## Fix
Pin to `npm@11.5.2` (the minimum version that supports OIDC trusted publishing) and add `--force` so the upgrade skips the broken self-rebuild step. No code change beyond the workflow.

## After merge
The 1.8.21 publish needs to be re-triggered manually since it didn't reach `npm publish`. Two options:
1. Re-run the failed `Publish` job from the Actions tab, or
2. Use `workflow_dispatch` on the `Publish` workflow.

## Test plan
- [ ] Re-trigger publish; `Install npm 11+` completes
- [ ] `Verify npm OIDC readiness` reports npm 11.5.2 and OIDC token URL present
- [ ] 1.8.21 publishes to npm with provenance
- [ ] Tag `v1.8.21` is pushed and a GitHub release is created