### PR TITLE
chore: add changeset for v2.0.0 icon library refresh

### DIFF
--- a/.changeset/icon-library-refresh.md
+++ b/.changeset/icon-library-refresh.md
@@ -1,5 +1,5 @@
 ---
-"@autoguru/icons": minor
+"@autoguru/icons": major
 ---
 
 Icon library refresh — replace 53 existing icons with updated designs, add 11 new icons (TikTok, X/Twitter, YouTube, Instagram filled, Afterpay filled, fg-plate, heart-filled, p-plate), and replace 167 legacy icons with Phosphor Icons

--- a/.changeset/icon-library-refresh.md
+++ b/.changeset/icon-library-refresh.md
@@ -1,0 +1,5 @@
+---
+"@autoguru/icons": minor
+---
+
+Icon library refresh — replace 53 existing icons with updated designs, add 11 new icons (TikTok, X/Twitter, YouTube, Instagram filled, Afterpay filled, fg-plate, heart-filled, p-plate), and replace 167 legacy icons with Phosphor Icons


### PR DESCRIPTION
## Summary

- Adds a major changeset for the icon library refresh (AG-19073, #69)
- Reverts the premature version bump so Changesets can handle the release properly (resets `package.json` version back to `1.8.22` and removes the manually-added `CHANGELOG.md` entry)

## Test plan

- [ ] Verify Changesets bot picks up the changeset and opens a "Version Packages" PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)