### PR TITLE
chore: add changeset for star icon Phosphor fill fix

### DIFF
--- a/.changeset/star-icon-phosphor-fill.md
+++ b/.changeset/star-icon-phosphor-fill.md
@@ -1,0 +1,5 @@
+---
+"@autoguru/icons": patch
+---
+
+Use Phosphor fill-weight star and star-half icons for correct rendering


### PR DESCRIPTION
Adds a patch changeset for PR #73, which switched the star and star-half icons to the Phosphor fill-weight versions for correct rendering. PR #73 was merged without a changeset, so nothing was queued for release.

This patch bumps `@autoguru/icons` from 2.0.0 to 2.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)