### PR TITLE
docs: sync v2.0.0 CHANGELOG with release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,20 @@
 
 ### Major Changes
 
--   02c8473: Icon library refresh — replace 53 existing icons with updated
-    designs, add 11 new icons (TikTok, X/Twitter, YouTube, Instagram filled,
-    Afterpay filled, fg-plate, heart-filled, p-plate), and replace 167 legacy
-    icons with Phosphor Icons
+-   02c8473: Icon library refresh — custom + Phosphor Icons (AG-19073, #69). A
+    full redesign of the icon set. **Breaking:** some icons were removed or
+    renamed, so exported icon component names have changed — consumers must
+    update imports for any affected icons. See `ICON-MIGRATION.md` for the full
+    old → new mapping.
+
+    -   **49** custom icons replaced with new designs from the design team
+        (filenames/export names unchanged).
+    -   **11** new custom icons added (no previous equivalent).
+    -   **171** icons replaced with
+        [Phosphor Icons](https://phosphoricons.com).
+    -   **2** original icons kept where no replacement was available.
+
+    Totals across `icons/`: 123 added, 154 removed, 77 modified.
 
 ## 1.8.22
 


### PR DESCRIPTION
## What

Updates the `## 2.0.0` entry in `CHANGELOG.md` to match the detailed breakdown in the [v2.0.0 GitHub release notes](https://github.com/autoguru-au/icons/releases/tag/v2.0.0).

The release shipped correctly (npm `@autoguru/icons@2.0.0`, tagged `latest`), but the auto-generated changeset text and the hand-edited GitHub release notes had diverged. This brings the CHANGELOG in line:

- **49** custom icons replaced with new designs (filenames/export names unchanged)
- **11** new custom icons added
- **171** icons replaced with Phosphor Icons
- **2** original icons kept
- Totals across `icons/`: 123 added, 154 removed, 77 modified

## Why

Changesets generates the CHANGELOG from the `.changeset/*.md` text and never reads the GitHub release body, so editing the release notes after the fact left the two out of sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)