### PR TITLE
chore: add changeset for full Phosphor 2.1 set (minor)

### DIFF
--- a/.changeset/full-phosphor-2-1-set.md
+++ b/.changeset/full-phosphor-2-1-set.md
@@ -1,0 +1,9 @@
+---
+"@autoguru/icons": minor
+---
+
+Add the full Phosphor 2.1 regular-weight set, AutoGuru custom icons, and a browsable category reference — bringing the library to **1,576 icons** (up from 203).
+
+- **Complete icon set.** Every SVG now lives directly in `icons/`, making the package self-contained — no external icon dependency or import tooling. Each icon is still emitted as an individual, tree-shakeable React component, and all existing export names are preserved.
+- **Category reference (`categories/`).** New documentation split into one page per category (20 pages, e.g. `categories/commerce.md`), generated from `categories/categories.json`. Docs only — not part of the build and not published.
+- **README** refreshed with clearer usage, naming, category, and contributing guidance.


### PR DESCRIPTION
Marks #77 (full Phosphor 2.1 regular-weight set, AutoGuru custom icons, and category reference) as a minor release. Purely additive — no existing icons removed or renamed — so it bumps 2.0.1 -> 2.1.0.

Please fill in this template

-   [ ] Use a meaningful title for the pull request
-   [ ] Optimise SVGs before you raise a pull request

Select one of these, and delete the others:

Adding an icon: `this will be marked as a patch`

-   [ ] Give the icon a meaningful name, preferably namespaced eg,
        car-windscreen rather than just windscreen.
-   [ ] Add svg to the icons/ folder, and raise the pull request

If moving, renaming or deleting an icon: `this will be marked as a minor`

-   [ ] Give the icon a meaningful name, preferably namespaced eg,
        car-windscreen rather than just windscreen.
-   [ ] Describe why the icon was renamed, moved or deleted.
-   [ ] If you are renaming an icon, and also adding an icon with the same name
        as the old renamed file. Please raise both of those in a single pull
        request, and annotate the pull request as a breaking change.
-   [ ] With an all caps "BREAKING CHANGE" at the bottom of the pull request,
        describe a migration path for this.

```
BREAKING CHANGE:
IconA is now IconB
IconC no longer exists, please use IconX instead
```

> Note, you don't need to tell us that IconA no longer exists, because of the
> rename.

---

Big icon changes will be marked as a major, but will probably be done manually
in 1 pull request, and versioned accordingly.
